### PR TITLE
Add optional hardwired dbspec to query generation

### DIFF
--- a/src/yesql/core.clj
+++ b/src/yesql/core.clj
@@ -6,23 +6,23 @@
 (defmacro defquery
   "Defines a query function, as defined in the given SQL file.
    Any comments in that file will form the docstring."
-  [name filename]
+  [name filename & options]
   ;;; TODO Now that we have a better parser, this is a somewhat suspicious way of writing this code.
   (let [query (->> filename
                    slurp-from-classpath
                    (format "-- name: %s\n%s" name)
                    parse-tagged-queries
                    first)]
-    (emit-def query)))
+    (emit-def query (first options))))
 
 (defmacro defqueries
   "Defines several query functions, as defined in the given SQL file.
    Each query in the file must begin with a `-- name: <function-name>` marker,
    followed by optional comment lines (which form the docstring), followed by
    the query itself."
-  [filename]
+  [filename & options]
   (let [queries (->> filename
                      slurp-from-classpath
                      parse-tagged-queries)]
     `(doall [~@(for [query queries]
-                 (emit-def query))])))
+                 (emit-def query (first options)))])))

--- a/test/yesql/core_test.clj
+++ b/test/yesql/core_test.clj
@@ -51,3 +51,14 @@
 
 (expect "'can't'"
         (:word (first (quoting derby-db))))
+
+;;; Defining macros with built-in db-spec values
+(defquery dbspec-query "yesql/sample_files/quoting.sql" {:db-spec derby-db})
+
+(expect "'can't'"
+        (:word (first (dbspec-query))))
+
+(defqueries "yesql/sample_files/dbspec.sql" {:db-spec derby-db})
+
+(expect java.util.Date
+        (:time (first (dbspec-parameters-query 1 2 3 4))))

--- a/test/yesql/sample_files/dbspec.sql
+++ b/test/yesql/sample_files/dbspec.sql
@@ -1,0 +1,8 @@
+-- name: dbspec-parameters-query
+SELECT CURRENT_TIMESTAMP AS time
+FROM SYSIBM.SYSDUMMY1
+WHERE :value1 = 1
+AND :value2 = 2
+AND ? = 3
+AND :value2 = 2
+AND ? = 4


### PR DESCRIPTION
For a single-database application, passing dbspec parameters around is
just code clutter. This change allows an optional map to be passed as an
extra parameter to defquery and defqueries. If it contains a key
:db-spec, the value will be used as the connection specifier for all the
generated JDBC calls, and the generated functions will not take it as an
initial parameter. So the following two snippets are equivalent:

(defquery myquery "xyz.sql")
(myquery db-spec 1 2 3 4)

(defquery myquery "xyz.sql" {:db-spec db-spec})
(myquery 1 2 3 4)
