### PR TITLE
Do not allow any nonwhitespace content after names

### DIFF
--- a/src/yesql/defqueries.bnf
+++ b/src/yesql/defqueries.bnf
@@ -5,7 +5,7 @@ docstring = comment+
 
 statement = line (line | <comment>)*
 
-name = <whitespace? COMMENT_MARKER whitespace? NAME_TAG whitespace?> non-whitespace any? <newline>
+name = <whitespace? COMMENT_MARKER whitespace? NAME_TAG whitespace?> non-whitespace <whitespace? newline>
 comment = <whitespace? COMMENT_MARKER whitespace?> !NAME_TAG (non-whitespace whitespace?)* newline
 line = whitespace? !COMMENT_MARKER (non-whitespace whitespace?)* newline
 


### PR DESCRIPTION
The parser was accepting content after names on name lines which causes
errors in the transform functions due to unexpected data.
