### PR TITLE
exclude external dependencies from jar file when AOT enabled

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,6 +19,7 @@
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0-alpha2"]]}}
   :aot [yesql.core]
+  :jar-exclusions [#"^clojure.*" #"^instaparse.*"]
   :core.typed {:check [yesql.annotations
                        yesql.util
                        yesql.instaparse-util


### PR DESCRIPTION
After enabling AOT, the yesql jar file will include some classes from its dependencies. This configuration will exclude them from jar file.
