### PR TITLE
Add link to Ruby port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Yesql has inspired ports to other languages:
 |Python|[Anosql](https://github.com/honza/anosql)|
 |Go|[DotSql](https://github.com/gchaincl/dotsql)|
 |C#|[JaSql](https://bitbucket.org/rick/jasql)|
+|Ruby|[yayql](https://github.com/gnarmis/yayql)|
 
 ## Development & Testing
 


### PR DESCRIPTION
This diff simply adds a link to the Ruby port of yesql to the README.md.