### PR TITLE
added the ability to take a hash containing query parameters

### DIFF
--- a/test/yesql/acceptance_test.clj
+++ b/test/yesql/acceptance_test.clj
@@ -24,7 +24,7 @@
 
 ;; Insert -> Select.
 (expect {:1 1M} (insert-person<! derby-db "Alice" 20))
-(expect {:1 2M} (insert-person<! derby-db "Bob" 25))
+(expect {:1 2M} (insert-person<! derby-db {:name "Bob", :age 25}))
 (expect {:1 3M} (insert-person<! derby-db "Charlie" 35))
 
 (expect 3 (count (find-older-than derby-db 10)))


### PR DESCRIPTION
The query functions will now overload and provide an implementation that takes a map of the params.  In the case that there's only one parameter it will detect whether that param is a map, and treat it appropriately.