### PR TITLE
Update README for underscore requirement in named parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ then you genuinely do need an abstraction layer on top of SQL.
 ## Usage
 ### One File, One Query
 
-Create an SQL query. Note we can supply named parameters and a comment string:
+Create an SQL query. Note we can supply named parameters and a comment string. The named parameters must use underscores rather than dashes:
 
 ```sql
 -- Counts the users in a given country.


### PR DESCRIPTION
There is currently a bug which prevents using dashes for named parameters in the query string.

For instance, this would fail in a where clause:
```
WHERE user.id = :user-id
```
and this would succeed:
```
WHERE user.id = :user_id
```
The README change makes that clear until the bug is fixed.