### PR TITLE
Pass empty IN-list parameters through to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The query will be automatically expanded to `... IN (1001, 1003, 1005)
 ...` under the hood, and work as expected.
 
 Just remember that some databases have a limit on the number of values
-in an `IN`-list, and Yesql makes no effort to circumvent such limits.
+in an `IN`-list, and Yesql makes no effort to circumvent such limits. Yesql won't protect you from empty `IN`-lists either. `([])` will be expanded to `... IN ()`.
 
 ### Insert/Update/Delete and More
 

--- a/src/yesql/named_parameters.clj
+++ b/src/yesql/named_parameters.clj
@@ -52,7 +52,7 @@ it as the pair `[string-with-?-parameters args]`, suitable for supply to `clojur
                                  remaining-args)
      (symbol? query-head) (recur (str query-string (args-to-placehoders args-head))
                                  (if (coll? args-head)
-                                   (apply conj final-args args-head)
+                                   (concat final-args args-head)
                                    (conj final-args args-head))
                                  query-tail
                                  args-tail))))

--- a/test/yesql/named_parameters_test.clj
+++ b/test/yesql/named_parameters_test.clj
@@ -53,6 +53,11 @@
         (reassemble-query (split-at-parameters "SELECT age FROM users WHERE country = :country AND name IN (:names)")
                           ["gb" ["tom" "dick" "harry"]]))
 
+;; Empty IN parameters are allowed to pass through to database
+(expect ["SELECT age FROM users WHERE country = ? AND name IN ()" "gb"]
+        (reassemble-query (split-at-parameters "SELECT age FROM users WHERE country = :country AND name IN (:names)")
+                          ["gb" []]))
+
 (expect AssertionError
         (reassemble-query (split-at-parameters "SELECT age FROM users WHERE country = :country AND name IN (:names)")
                           ["gb"]))


### PR DESCRIPTION
Empty `IN`-list parameters are now expanded to `... IN ()` rather than throwing an error. For example:

```clojure
(reassemble-query (split-at-parameters "SELECT age FROM users WHERE country = :country AND name IN (:names)")
		  ["gb" []])
=> ["SELECT age FROM users WHERE country = ? AND name IN ()" "gb"]
```

Previously this would have thrown a difficult to interpret error (see Issue #25). The invalid SQL statement is now allowed to be passed through to the database.

A corresponding test is added showing reassemble-query produces an (invalid) sql query when passed an empty vector for an in-list parameter. A snippet of documentation is also added to the README.