### PR TITLE
Allow apostrophes in in-line SQL comments

### DIFF
--- a/src/yesql/statement.bnf
+++ b/src/yesql/statement.bnf
@@ -1,6 +1,9 @@
 statement = substatement (parameter substatement)*
 
-substatement = (( #"[^?:']+" | "::") | string)*
+substatement = (( #"[^?:']+" | "::" ) | comment | string)*
+
+comment = (whitespace? COMMENT_MARKER whitespace? (non-whitespace whitespace*)* newline)
+COMMENT_MARKER = "--"
 
 string = string-delimiter string-normal* (string-special string-normal*)* string-delimiter
 string-delimiter = "'"
@@ -13,4 +16,6 @@ placeholder-parameter = "?"
 
 named-parameter = <":"> #"[^\s,\"':&;()|=+\-*%/\\<>^]+"
 
+newline = '\n' | '\r\n'
+non-whitespace = #'\S+'
 whitespace = (' ' | '\t')+

--- a/src/yesql/statement_parser.clj
+++ b/src/yesql/statement_parser.clj
@@ -10,7 +10,8 @@
   (instaparse/parser (io/resource "yesql/statement.bnf")))
 
 (def ^:private parser-transforms
-  {:statement vector
+  {:whitespace str-non-nil
+   :statement vector
    :substatement str-non-nil
    :string str-non-nil
    :string-special str-non-nil
@@ -18,7 +19,11 @@
    :string-normal identity
    :parameter identity
    :placeholder-parameter symbol
-   :named-parameter symbol})
+   :non-whitespace str-non-nil
+   :newline identity
+   :named-parameter symbol
+   :COMMENT_MARKER identity
+   :comment str-non-nil})
 
 (defn- parse-statement
   [statement context]

--- a/test/yesql/generate_test.clj
+++ b/test/yesql/generate_test.clj
@@ -81,7 +81,13 @@
   "SELECT * FROM users WHERE group_ids IN(:group_ids) AND parent_id = :parent_id"
   {:group_ids [1 2]
    :parent_id 3}
-  => ["SELECT * FROM users WHERE group_ids IN(?,?) AND parent_id = ?" 1 2 3]) 
+  => ["SELECT * FROM users WHERE group_ids IN(?,?) AND parent_id = ?" 1 2 3]
+
+;;; Allow apostrophes within in-line comments 
+  "SELECT age FROM users WHERE country = :country -- '\nAND name = :name"
+  {:country "gb"
+   :name "tom"}
+  => ["SELECT age FROM users WHERE country = ? -- '\nAND name = ?" "gb" "tom"])
 
 ;;; Incorrect parameters.
 (expect AssertionError


### PR DESCRIPTION
The SQL string element in the statement.bnf file allows arbitrary string (ie ":") to be placed within apostrophe delimiters ("'").  However, this prevents the use of opening apostrophes without a closing apostrophe inside of inline comments. For example, the following statement causes a parse error:

```sql
SELECT country FROM users -- This "'" causes an error
WHERE user = 'tom'
```

This parse error is corrected by creating a comment element delimited by "--" and a newline, allowing any arbitrary characters between them. This closes issue #69.