### PR TITLE
Allow assignment variable ":=" within queries

### DIFF
--- a/src/yesql/statement.bnf
+++ b/src/yesql/statement.bnf
@@ -1,6 +1,6 @@
 statement = substatement (parameter substatement)*
 
-substatement = (( #"[^?:']+" | "::") | string)*
+substatement = (( #"[^?:']+" | "::" | ":=") | string)*
 
 string = string-delimiter string-normal* (string-special string-normal*)* string-delimiter
 string-delimiter = "'"

--- a/test/yesql/statement_parser_test.clj
+++ b/test/yesql/statement_parser_test.clj
@@ -39,6 +39,10 @@
   "SELECT :value, :other_value, 5::text FROM dual"
   => ["SELECT " value ", " other_value ", 5::text FROM dual"]
 
+  ;; Assignment
+  "DECLARE some varchar:='a value';BEGIN SELECT :value, :other_value FROM dual;END;"
+  => ["DECLARE some varchar:='a value';BEGIN SELECT " value ", " other_value " FROM dual;END;"]
+
   ;; Newlines are preserved.
   "SELECT :value, :other_value, 5::text\nFROM dual"
   => ["SELECT " value ", " other_value ", 5::text\nFROM dual"]


### PR DESCRIPTION
The assignment operator "`:=`" is intepreted as an invalid named variable by yesql, causing a parse error (see issue #80).  Yesql already has special allowance in the statement.bnf file for the casting operator "`::`".  I've extended that support to also include the assignment operator "`:=`".

This has a side effect of intepreting named-variables beginning with an "`=`" sign (valid clojure) as assignments to the rest of the variable name. For example:

```clojure
"SELECT * FROM country WHERE country = :=invalid-named-variable;"
=> ["SELECT * FROM country WHERE country = :=invalid-named-variable;"]
```

It does not throw a parse error because the named-variable `=invalid-named-variable` is interpreted as an assignment `:= invalid-named-variable`.