### PR TITLE
Learned -q! to skip parameter parsing and just create a function with the statement

### DIFF
--- a/src/yesql/types.clj
+++ b/src/yesql/types.clj
@@ -51,21 +51,26 @@
 (defn- emit-query-fn
   "Emit function to run a query.
 
+   - If the query name ends in `-q!`, it will call `clojure.java.jdbc/execute` and not process params,
    - If the query name ends in `!` it will call `clojure.java.jdbc/execute!`,
    - If the query name ends in `<!` it will call `clojure.java.jdbc/insert!`,
    - otherwise `clojure.java.jdbc/query` will be used."
   [{:keys [name docstring statement]}]
-  (let [split-query (split-at-parameters statement)
-        {:keys [query-args display-args function-args]} (split-query->args split-query)
-        jdbc-fn (cond
-                 (= [\< \!] (take-last 2 name)) `insert-handler
-                 (= \! (last name)) `execute-handler
-                 :else `jdbc/query)]
-    `(def ~(fn-symbol (symbol name) docstring statement display-args)
-       (fn [db# ~@function-args]
-         (~jdbc-fn db#
-                   (reassemble-query '~split-query
-                                     ~query-args))))))
+  (if (= [\- \q \!] (take-last 3 name))
+    `(def ~(fn-symbol (symbol name) docstring statement [])
+       (fn [db#] 
+         (~`execute-handler db# [~statement])))
+    (let [split-query (split-at-parameters statement)
+          {:keys [query-args display-args function-args]} (split-query->args split-query)
+          jdbc-fn (cond
+                    (= [\< \!] (take-last 2 name)) `insert-handler
+                    (= \! (last name)) `execute-handler
+                    :else `jdbc/query)]
+      `(def ~(fn-symbol (symbol name) docstring statement display-args)
+         (fn [db# ~@function-args]
+           (~jdbc-fn db#
+                     (reassemble-query '~split-query
+                                       ~query-args)))))))
 
 ;; ## Query Emitter
 (defrecord Query [name docstring statement]

--- a/test/yesql/types_test.clj
+++ b/test/yesql/types_test.clj
@@ -1,0 +1,14 @@
+(ns yesql.types_test
+  (:require [yesql.types :as types]
+            [expectations :refer :all]))
+
+(def unparseable-statement "CREATE FUNCTION foo() RETURNS int AS $$ DECLARE x int := 0; BEGIN RETURN (SELECT x+1); END; $$ LANGUAGE plpgsql;")
+
+(require 'clojure.walk)
+(clojure.walk/macroexpand-all '(let [fn-arg {:statement unparseable-statement
+                              :name "foo-q!"
+                              :docstring ""}
+                      fn-code (#'types/emit-query-fn fn-arg)]
+                  (with-redefs [yesql.types/execute-handler (fn [_ [s]] s)]
+                    (eval fn-code) ;; creates #'foo-q!
+                    (expect unparseable-statement (foo-q!)))))


### PR DESCRIPTION
Functions named foo-q! will `clojure.java.jdbc/execute!` the statement
without attempting to parse the statement for variables. This is ideal
for situations where you have DDL such as table or functions to load.