### PR TITLE
Allow spaces after name tag

### DIFF
--- a/test/yesql/core_test.clj
+++ b/test/yesql/core_test.clj
@@ -90,7 +90,7 @@
 
 ;;; Check defqueries returns the list of defined vars.
 (expect-let [return-value (defqueries "yesql/sample_files/combined_file.sql")]
-  (repeat 3 clojure.lang.Var)
+  (repeat 4 clojure.lang.Var)
   (map type return-value))
 
 ;;; SQL's quoting rules.


### PR DESCRIPTION
Any alphanumeric characters after the name tag were causing an terse error (see Issue #75).  This happened whenever any alphanumeric characers appeared after the name in a `--name: my-name` comment. 

The error was thrown because the name tag is parsed and transformed into a three element vector: `[:name name-string extra-alphanumeric-chars]`.  This was then passed to be merged using `(merge {} ...)`, which wanted to treat the vector as a two element hash-node. The three element vector caused the error.

Pulled in a parser update up from devel to solve the bug.