### PR TITLE
added the ability to take a hash containing query parameters

### DIFF
--- a/test/yesql/acceptance_test.clj
+++ b/test/yesql/acceptance_test.clj
@@ -24,7 +24,7 @@
 
 ;; Insert -> Select.
 (expect {:1 1M} (insert-person<! derby-db "Alice" 20))
-(expect {:1 2M} (insert-person<! derby-db "Bob" 25))
+(expect {:1 2M} (insert-person<! derby-db {:name "Bob", :age 25}))
 (expect {:1 3M} (insert-person<! derby-db "Charlie" 35))
 
 (expect 3 (count (find-older-than derby-db 10)))


### PR DESCRIPTION
For many use cases, positional query parameters lead to a lot of manual packing / unpacking.  This patch adds an alternative signature to the generated functions which will accept 2 args, a connection and a map of param-name -> value. If the query only has a single arg it distinguishes a value param vs a map param based on type.