### PR TITLE
Allows function as input to defquer-y/ies

### DIFF
--- a/src/yesql/core.clj
+++ b/src/yesql/core.clj
@@ -8,7 +8,7 @@
    Any comments in that file will form the docstring."
   [name filename]
   ;;; TODO Now that we have a better parser, this is a somewhat suspicious way of writing this code.
-  (let [query (->> filename
+  (let [query (->> (eval filename)
                    slurp-from-classpath
                    (format "-- name: %s\n%s" name)
                    parse-tagged-queries
@@ -21,7 +21,7 @@
    followed by optional comment lines (which form the docstring), followed by
    the query itself."
   [filename]
-  (let [queries (->> filename
+  (let [queries (->> (eval filename)
                      slurp-from-classpath
                      parse-tagged-queries)]
     `(doall [~@(for [query queries]

--- a/test/yesql/core_test.clj
+++ b/test/yesql/core_test.clj
@@ -46,6 +46,20 @@
   [(var the-time) (var sums) (var edge)]
   return-value)
 
+;;; Check that a function returning the path can be passed to the defquery
+;;; and defqueries macros
+
+(defn path-to-sql [filename]
+  (clojure.string/join "/" ["yesql/sample_files" filename]))
+
+(expect
+  (defqueries (path-to-sql "combined_file.sql"))
+  (defqueries "yesql/sample_files/combined_file.sql"))
+
+(expect
+  (defquery mixed-params (path-to-sql "combined_file.sql"))
+  (defquery mixed-params "yesql/sample_files/mixed_parameters.sql"))
+
 ;;; SQL's quoting rules.
 (defquery quoting "yesql/sample_files/quoting.sql")
 


### PR DESCRIPTION
I wanted to be able to pass a function that returns the path of the sql files to `defqueries` and `defquery`, so that I don't have to keep repeating the path to the containing folder. I didn't find a way to quote/unquote to get it working, but I don't have much macro knowledge, so if there's a better way, I'm happy to fix it up.