### PR TITLE
Parse the statement only once per query

### DIFF
--- a/test/yesql/generate_test.clj
+++ b/test/yesql/generate_test.clj
@@ -1,6 +1,7 @@
 (ns yesql.generate-test
   (:require [expectations :refer :all]
             [clojure.template :refer [do-template]]
+            [yesql.statement-parser :refer [tokenize]]
             [yesql.generate :refer :all]))
 
 (do-template [statement _ expected-parameters]
@@ -31,7 +32,7 @@
 ;;; Testing reassemble-query
 (do-template [statement parameters _ rewritten-form]
   (expect rewritten-form
-          (rewrite-query-for-jdbc statement
+          (rewrite-query-for-jdbc (tokenize statement)
                                   parameters))
 
   "SELECT age FROM users WHERE country = :country"
@@ -85,9 +86,9 @@
 
 ;;; Incorrect parameters.
 (expect AssertionError
-        (rewrite-query-for-jdbc "SELECT age FROM users WHERE country = :country AND name = :name"
+        (rewrite-query-for-jdbc (tokenize "SELECT age FROM users WHERE country = :country AND name = :name")
                                 {:country "gb"}))
 
 (expect AssertionError
-        (rewrite-query-for-jdbc "SELECT age FROM users WHERE country = ? AND name = ?"
+        (rewrite-query-for-jdbc (tokenize "SELECT age FROM users WHERE country = ? AND name = ?")
                                 {}))


### PR DESCRIPTION
This patch moves the invocation of y.statement-parser/tokenize to
y.generate/generate-query-fn. As a result tokenising happens only
once per query, instead of once per invocation.

y.generate/rewrite-query-for-jdbc accepts tokens as its first argument.

This patch has significantly reduced CPU usage of our Yesql 0.5
application.

Thanks to @xsc  for helping me prepare this patch.