### PR TITLE
Trims One Semicolon at the End of Each Statement

### DIFF
--- a/src/yesql/queryfile_parser.clj
+++ b/src/yesql/queryfile_parser.clj
@@ -1,6 +1,6 @@
 (ns yesql.queryfile-parser
   (:require [clojure.java.io :as io]
-            [clojure.string :refer [join trim]]
+            [clojure.string :as str :refer [join trim]]
             [instaparse.core :as instaparse]
             [yesql.types :refer [map->Query]]
             [yesql.util :refer [str-non-nil]]
@@ -10,6 +10,9 @@
   (let [url (io/resource "yesql/queryfile.bnf")]
     (assert url)
     (instaparse/parser url)))
+
+(defn- rm-semicolon [s]
+  (str/replace s #";$" ""))
 
 (def parser-transforms
   {:whitespace str-non-nil
@@ -22,7 +25,7 @@
    :docstring (fn [& comments]
                 [:docstring (trim (join (map second comments)))])
    :statement (fn [& lines]
-                [:statement (trim (join lines))])
+                [:statement (rm-semicolon (trim (join lines)))])
    :query (fn [& args]
             (map->Query (into {} args)))
    :queries list})


### PR DESCRIPTION
If I use the defqueries mode where I have more than one query in one SQL
file, I have a problem with my editor. I use IntelliJ and it likes to
have semicolons at the end of each statement. Otherwise its not able to
parse the statements and therefore can't provide error checking and
other stuff. However my Oracle database does not like the semicolons if
I run the query.