### PR TITLE
Add option for caching using clojure.core.memoize

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.7"]
-                 [instaparse "1.4.1"]]
+                 [instaparse "1.4.1"]
+                 [org.clojure/core.memoize "0.5.6"]]
   :scm {:name "git"
         :url "https://github.com/krisajenkins/yesql"}
   :profiles {:dev {:dependencies [[expectations "2.1.2"]


### PR DESCRIPTION
Hey Krisa

Love your library but I was experiencing some bad performance when repeatedly issuing identical queries.

I thought I might integrate clojure's memoization into yesql so we can manually specify queries we would like to cache.

I used ttl memoization with a default timeout of 60 seconds, and queries are untouched unless you explicity append `$` to the query name, in which case caching is enabled.

```
=> (time (counts$ { :start_time test-start-time :end_time test-end-time :page_ids [1633475046886434 123]}))
"Elapsed time: 2737.603783 msecs"
=> (time (counts$ { :start_time test-start-time :end_time test-end-time :page_ids [1633475046886434 123]}))
"Elapsed time: 12.324543 msecs" ; <== 200x speedup!!
```

WAIT 60+ seconds

```
(time (counts$ { :start_time test-start-time :end_time test-end-time :page_ids [1633475046886434 123]}))
"Elapsed time: 2932.854211 msecs"
```