### PR TITLE
Sam/upstream union

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: clojure
 lein: lein2
 script: lein2 test-all

--- a/project.clj
+++ b/project.clj
@@ -14,8 +14,9 @@
                              [lein-expectations "0.0.8"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-RC1"]]}}
-  :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7" "do"
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0-alpha4"]]}}
+  :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7:+1.8" "do"
                         ["clean"]
                         ["expectations"]]
             "test-ancient" ["expectations"]})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject yesql "0.5.0-rc3"
+(defproject yesql "0.5.0-rc4"
   :description "A Clojure library for using SQL"
   :url "https://github.com/krisajenkins/yesql"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/java.jdbc "0.3.7"]
-                 [instaparse "1.4.0"]]
+                 [instaparse "1.4.1"]]
   :scm {:name "git"
         :url "https://github.com/krisajenkins/yesql"}
-  :profiles {:dev {:dependencies [[expectations "2.1.1"]
+  :profiles {:dev {:dependencies [[expectations "2.1.2"]
                                   [org.apache.derby/derby "10.11.1.1"]]
                    :plugins [[lein-autoexpect "1.4.0"]
                              [lein-expectations "0.0.8"]]}


### PR DESCRIPTION
Adds union support to yesql.

Main use is via a helper macro called yesql.union/union-sql. You call it like this:

`(union-sql [(query1 params) (query2 params)] { :optional :options })`