### PR TITLE
Update README, remove the 'lein typed check' instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,9 @@ Yesql uses the marvellous
 for tests. It's like clojure.test, but has lighter-weight syntax and
 much better failure messages.
 
-Call `lein test` to run the test suite.  
-Call `lein typed check` to run core.typed checking.  
-Call `lein test-all` to run the tests against all (supported) versions of Clojure.  
-Call `lein autoexpect` to automatically re-run the tests as source files change.  
+Call `lein test` to run the test suite.
+Call `lein test-all` to run the tests against all (supported) versions of Clojure.
+Call `lein autoexpect` to automatically re-run the tests as source files change.
 
 ## Other Languages
 


### PR DESCRIPTION
The project is not using core.typed any more, this step is unnecesary.