### PR TITLE
Adding support for clojure.java.jdbc/query's :as-arrays? key 

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ FROM dual;
                   :row-fn :sysdate
                   :identifiers identity})
 ;=> #inst "2014-09-30T07:30:06.764000000-00:00"
+
+;;; With :as-arrays? you get ordered vectors instead of unordered maps.
+;;; Useful if you want to preserve the column ordering of your SQL statement:
+(find-older-than {:age 20} {:as-arrays? true})
+;=> ([:person_id :name :age] [1 "Betty" 21] [2 "Betsy" 22] [3 "Becky" 23])
 ```
 
 As with `clojure.java.jdbc` the default `:result-set-fn` is `doall`,

--- a/src/yesql/generate.clj
+++ b/src/yesql/generate.clj
@@ -81,7 +81,7 @@
 
 (defn query-handler
   [db sql-and-params
-   {:keys [row-fn result-set-fn identifiers]
+   {:keys [row-fn result-set-fn identifiers as-arrays?]
     :or {identifiers lower-case
          row-fn identity
          result-set-fn doall}
@@ -89,7 +89,8 @@
   (jdbc/query db sql-and-params
               :identifiers identifiers
               :row-fn row-fn
-              :result-set-fn result-set-fn))
+              :result-set-fn result-set-fn
+              :as-arrays? as-arrays?))
 
 (defn generate-query-fn
   "Generate a function to run a query.

--- a/test/yesql/core_test.clj
+++ b/test/yesql/core_test.clj
@@ -52,6 +52,13 @@
                                 :identifiers clojure.string/upper-case
                                 :row-fn :TIME}))
 
+;;; Check that :as-arrays? option returns a seq of ordered vectors instead of unordered maps
+(expect [:time] (current-time-query {} {:result-set-fn first
+                                        :as-arrays? true}))
+
+(expect java.util.Date (first (current-time-query {} {:result-set-fn second
+                                                      :as-arrays? true})))
+
 ;;; Test comment rules.
 (defquery inline-comments-query
   "yesql/sample_files/inline_comments.sql"


### PR DESCRIPTION
Fix for https://github.com/krisajenkins/yesql/issues/115
Allows passing through an :as-arrays? key to java.jdbc to get the results as a list of ordered vectors instead of unordered maps, in case the SQL statement column ordering matters to the client code.

Example:
```clojure
(find-older-than {:age 20})
;=> ({:age 21, :name "Betty", :person_id 1} {:age 22, :name "Betsy", :person_id 2} {:age 23, :name "Becky", :person_id 3})

(find-older-than {:age 20} {:as-arrays? true})
;=> ([:person_id :name :age] [1 "Betty" 21] [2 "Betsy" 22] [3 "Becky" 23])
```