### PR TITLE
Emit empty sequences as NULL

### DIFF
--- a/src/yesql/generate.clj
+++ b/src/yesql/generate.clj
@@ -13,9 +13,15 @@
 
 (defn- args-to-placeholders
   [args]
-  (if (in-list-parameter? args)
-    (clojure.string/join "," (repeat (count args) "?"))
-    "?"))
+  ;; First clause is a workaround to get [] () and nil to work the same in a
+  ;; query. It has the additional benefit that empty arguments to IN-clauses
+  ;; always expands into "IN (NULL)", and according to the SQL spec this will
+  ;; never match anything.
+  (cond (and (in-list-parameter? args) (empty? args))
+          "NULL"
+        (in-list-parameter? args)
+          (clojure.string/join "," (repeat (count args) "?"))
+        :else "?"))
 
 (defn- analyse-statement-tokens
   [tokens]

--- a/test/yesql/generate_test.clj
+++ b/test/yesql/generate_test.clj
@@ -73,11 +73,11 @@
    :data {:a 1}}
   => ["INSERT INTO json (data, source) VALUES (?, ?)" {:a 1} "google"]
 
-;;; Empty IN-lists are allowed by Yesql - though most DBs will complain.
+;;; Empty IN-lists are allowed by Yesql: They will be expanded into NULL
   "SELECT age FROM users WHERE country = :country AND name IN (:names)"
   {:country "gb"
    :names []}
-  => ["SELECT age FROM users WHERE country = ? AND name IN ()" "gb"]
+  => ["SELECT age FROM users WHERE country = ? AND name IN (NULL)" "gb"]
 
   "SELECT * FROM users WHERE group_ids IN(:group_ids) AND parent_id = :parent_id"
   {:group_ids [1 2]


### PR DESCRIPTION
Hi!

I had some trouble with my queries in Postgres, where, when I passed empty vectors and lists, caused them to throw exceptions. This was, of course, because `IN (:foo)` expanded into `IN ()` which is not legal SQL syntax (at least Postgres doesn't like it).

The change I did in my code was simply to call `seq` on the offending parameters, which caused the parameter to be treated as the "value" NULL instead. The queries expanded into `IN (NULL)`, which – if I have read the SQL specification right – will never match anything because any comparison with NULL always return false.

This works, but I feel it's a bit unfortunate that I as a user must do the `seq` call right before executing the code. It's specially bothersome if the parameter map is modified or used downstream, e.g. by doing something as innocent as `(update-in params [:foo] filter my-pred)`, which causes nil to be converted into `()`.

So I decided to modify the source slightly, so that `[]`, `()` and `nil` now expands to the same thing semantically: `NULL`. The change is small and shouldn't be too hard to understand.

---

The only potential problem I can see with this change is strange expansion outside of IN-clauses. Consider the statement

```sql
INSERT INTO users (username) VALUES (:name)
```

With the current implementation, this will fail if you set `:name` to an empty vector, but will silently succeed with this proposal. However, this will also silently succeed with a single-element vector regardless of this patch, and as such I don't believe this is a big issue in practice.