### PR TITLE
Fix named-parameter regex to exclude square brackets

### DIFF
--- a/src/yesql/statement.bnf
+++ b/src/yesql/statement.bnf
@@ -11,6 +11,6 @@ parameter = placeholder-parameter | named-parameter
 
 placeholder-parameter = "?"
 
-named-parameter = <":"> #"[^\s,\"':&;()|=+\-*%/\\<>^]+"
+named-parameter = <":"> #"[^\s,\"':&;()|=+\-*%/\\<>^\[\]]+"
 
 whitespace = (' ' | '\t')+

--- a/test/yesql/statement_parser_test.clj
+++ b/test/yesql/statement_parser_test.clj
@@ -48,4 +48,7 @@
   => ["SELECT " a "+2*" b "+age::int FROM users WHERE username = " ? " AND " b " > 0"]
 
   "SELECT :value1 + ? + value2 + ? + :value1\nFROM SYSIBM.SYSDUMMY1"
-  => ["SELECT " value1 " + " ? " + value2 + " ? " + " value1 "\nFROM SYSIBM.SYSDUMMY1"])
+  => ["SELECT " value1 " + " ? " + value2 + " ? " + " value1 "\nFROM SYSIBM.SYSDUMMY1"]
+
+  "SELECT ARRAY [:value1] FROM dual"
+  => ["SELECT ARRAY [" value1 "] FROM dual"])


### PR DESCRIPTION
This is valid in Postgres: 
```sql
SELECT ARRAY[1, 2, 3]
```

It's possible to use this in a YeSQL query by doing `SELECT [:foo ]`, and passing `{:foo [1 2 3]}` as the parameters, but if you don't leave a trailing space after `:foo` then the parameter name gets tokenised to `:foo]`, causing a query argument mismatch.