### PR TITLE
Allowed choosing the IN-list data structure type

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,26 @@ The query will be automatically expanded to `... IN (1001, 1003, 1005)
 Just remember that some databases have a limit on the number of values
 in an `IN`-list, and Yesql makes no effort to circumvent such limits.
 
+By default, vectors, lists and seqs are automatically expanded as explained
+above, but this behaviour can be overridden by passing an extra parameter
+to the query creation functions (`defquery`, `defqueries` and `require-sql`):
+
+```clojure
+(defqueries "some/where/queryfile.sql"
+  {:connection db-spec
+   :in-list-parameter-predicate set?})
+
+(find-users {:id #{1001 1003 1005}
+             :maxage 18})
+```
+
+In this way you can use data structures such as vectors for other purposes,
+for example you are free to use `PostgreSQL`'s ARRAYs.
+The `:in-list-parameter-predicate` must be a predicate used to identify
+the data structure that must be expanded, but keep in mind that the choosen
+data structure must respond to the `Seq` interface. A `nil` value selects
+the default behaviour.
+
 ### Row And Result Processors
 
 Like `clojure.java.jdbc`, Yesql accepts functions to pre-process each

--- a/test/yesql/acceptance_test.clj
+++ b/test/yesql/acceptance_test.clj
@@ -89,3 +89,4 @@
 
 (expect SQLSyntaxErrorException
         (syntax-error))
+

--- a/test/yesql/acceptance_test_custom_in_list.clj
+++ b/test/yesql/acceptance_test_custom_in_list.clj
@@ -1,0 +1,31 @@
+(ns yesql.acceptance-test-custom-in-list
+  (:require [expectations :refer :all]
+            [clojure.java.jdbc :as jdbc]
+            [yesql.core :refer :all])
+  (:import [java.sql SQLException SQLSyntaxErrorException SQLDataException]))
+
+(def derby-db {:subprotocol "derby"
+               :subname (gensym "memory:")
+               :create true})
+
+;;; Multiple-query workflow.
+(defqueries
+  "yesql/sample_files/acceptance_test_combined.sql"
+  {:connection derby-db :in-list-parameter-predicate set?})
+
+;; Create
+(expect (create-person-table!))
+
+;; Insert -> Select.
+(expect {:1 1M} (insert-person<! {:name "Alice"
+                                  :age 20}))
+(expect {:1 2M} (insert-person<! {:name "Bob"
+                                  :age 25}))
+(expect {:1 3M} (insert-person<! {:name "Charlie"
+                                  :age 35}))
+
+;;; Select with IN.
+(expect 2 (count (find-by-age {:age #{20 35}})))
+
+;; Drop
+(expect (drop-person-table!))

--- a/test/yesql/generate_test.clj
+++ b/test/yesql/generate_test.clj
@@ -22,7 +22,7 @@
 
 ;;; Testing in-list-parmaeter for "IN-list" statements.
 (expect [true true true false false]
-        (map in-list-parameter?
+        (map default-in-list-parameter?
              (list []
                    (list)
                    (lazy-seq (cons 1 [2]))


### PR DESCRIPTION
Currently it is impossible to interact with PostgreSQL advanced data types such as arrays because vectors are intercepted for the IN clause expansion. The `set` data type seems more suitable (after all, semantically it is a set membership operation), but I made it configurable. I didn't change the default, however: if you want to change the behaviour you have to pass an explicit option.