### PR TITLE
Update to latest, released java.jdbc version (0.5.8)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,22 +1,23 @@
-(defproject yesql "0.5.2"
+(defproject yesql "0.5.8"
   :description "A Clojure library for using SQL"
   :url "https://github.com/krisajenkins/yesql"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/java.jdbc "0.4.2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/java.jdbc "0.5.8"]
                  [instaparse "1.4.1" :exclusions [org.clojure/clojure]]]
   :pedantic? :abort
   :scm {:name "git"
         :url "https://github.com/krisajenkins/yesql"}
   :profiles {:dev {:dependencies [[expectations "2.1.3" :exclusions [org.clojure/clojure]]
                                   [org.apache.derby/derby "10.11.1.1"]]
-                   :plugins [[lein-autoexpect "1.4.0"]
-                             [lein-expectations "0.0.8"]]}
+                   :plugins      [[lein-autoexpect "1.4.0"]
+                                  [lein-expectations "0.0.8"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             }
   :aliases {"test-all" ["with-profile" "+1.5:+1.6:+1.7:+1.8" "do"
                         ["clean"]
                         ["expectations"]]

--- a/src/yesql/generate.clj
+++ b/src/yesql/generate.clj
@@ -76,8 +76,8 @@
   (first (jdbc/execute! db sql-and-params)))
 
 (defn insert-handler
-  [db statement-and-params call-options]
-  (jdbc/db-do-prepared-return-keys db statement-and-params))
+  [db sql-and-params call-options]
+  (jdbc/db-do-prepared-return-keys db sql-and-params))
 
 (defn query-handler
   [db sql-and-params

--- a/src/yesql/generate.clj
+++ b/src/yesql/generate.clj
@@ -76,20 +76,20 @@
   (first (jdbc/execute! db sql-and-params)))
 
 (defn insert-handler
-  [db [statement & params] call-options]
-  (jdbc/db-do-prepared-return-keys db statement params))
+  [db statement-and-params call-options]
+  (jdbc/db-do-prepared-return-keys db statement-and-params))
 
 (defn query-handler
   [db sql-and-params
    {:keys [row-fn result-set-fn identifiers]
-    :or {identifiers lower-case
-         row-fn identity
+    :or {identifiers   lower-case
+         row-fn        identity
          result-set-fn doall}
     :as call-options}]
   (jdbc/query db sql-and-params
-              :identifiers identifiers
-              :row-fn row-fn
-              :result-set-fn result-set-fn))
+              {:identifiers   identifiers
+               :row-fn        row-fn
+               :result-set-fn result-set-fn}))
 
 (defn generate-query-fn
   "Generate a function to run a query.


### PR DESCRIPTION
Got rid of depreciation warnings from java.jdbc 0.5.8, which also preps for the upcoming java.jdbc 0.6.0 release.

Note: Updated yesql version to 0.5.8 to bring it inline with java.jdbc version (not sure your versioning strategy).

Feel free to merge all, parts, or none of the changes.

Thanks for the great library,

-ck