### PR TITLE
Connection as a function #99

### DIFF
--- a/src/yesql/generate.clj
+++ b/src/yesql/generate.clj
@@ -108,10 +108,12 @@
                   :else query-handler)
         required-args (expected-parameter-list statement)
         global-connection (:connection query-options)
+        global-connection-fn (:connection-fn query-options)
         tokens (tokenize statement)
         real-fn (fn [args call-options]
                   (let [connection (or (:connection call-options)
-                                       global-connection)]
+                                       global-connection
+                                       (and (fn? global-connection-fn) (global-connection-fn)))]
                     (assert connection
                             (format (join "\n"
                                           ["No database connection supplied to function '%s',"
@@ -124,8 +126,8 @@
                                                                                       required-args))]
                                                              {:keys as-vec}
                                                              {})
-                                                global-args {:keys ['connection]}]
-                                            (if global-connection
+                                                global-args {:keys ['connection 'connection-fn]}]
+                                            (if (or global-connection global-connection-fn)
                                               (if (empty? required-args)
                                                 [(list []
                                                        [named-args global-args])

--- a/test/yesql/core_test.clj
+++ b/test/yesql/core_test.clj
@@ -17,6 +17,10 @@
   "yesql/sample_files/current_time.sql"
   {:connection derby-db})
 
+(defquery connection-fn-query
+  "yesql/sample_files/current_time.sql"
+  {:connection-fn (fn [] derby-db)})
+
 (defquery mixed-parameters-query
   "yesql/sample_files/mixed_parameters.sql"
   {:connection derby-db})
@@ -25,6 +29,10 @@
 (expect (more-> java.util.Date
                 (-> first :time))
         (current-time-query))
+
+(expect (more-> java.util.Date
+                (-> first :time))
+        (connection-fn-query))
 
 (expect (more-> java.util.Date
                 (-> first :time))
@@ -64,7 +72,7 @@
 ;;; Test Metadata.
 (expect (more-> "Just selects the current time.\nNothing fancy." :doc
                 'current-time-query :name
-                (list '[] '[{} {:keys [connection]}]) :arglists)
+                (list '[] '[{} {:keys [connection connection-fn]}]) :arglists)
         (meta (var current-time-query)))
 
 (expect (more->  "Here's a query with some named and some anonymous parameters.\n(...and some repeats.)" :doc
@@ -78,7 +86,7 @@
 
                  2 (-> :arglists second count)
                  #{'? 'value1 'value2} (-> :arglists second first  :keys set)
-                 #{'connection}        (-> :arglists second second :keys set))
+                 #{'connection 'connection-fn} (-> :arglists second second :keys set))
         (meta (var mixed-parameters-query)))
 
 ;; Running a query in a transaction and using the result outside of it should work as expected.


### PR DESCRIPTION
This pull request is related to issue #99. I find having `:connection-fn` option is necessary when you use [mount](https://github.com/tolitius/mount) and inject datasource stored in a state.
