### PR TITLE
Fix require-sql to use . instead of / in internal ns name

### DIFF
--- a/src/yesql/core.clj
+++ b/src/yesql/core.clj
@@ -1,7 +1,8 @@
 (ns yesql.core
   (:require [yesql.util :refer [slurp-from-classpath]]
             [yesql.generate :refer [generate-var]]
-            [yesql.queryfile-parser :refer [parse-tagged-queries]]))
+            [yesql.queryfile-parser :refer [parse-tagged-queries]]
+            [clojure.string :as str]))
 
 (defn defqueries
   "Defines several query functions, as defined in the given SQL file.
@@ -47,7 +48,7 @@
     (throw (Exception. "Missing an :as or a :refer")))
   (let [current-ns (ns-name *ns*)
         ;; Keep this .sql file's defqueries in a predictable place:
-        target-ns (symbol (str "yesquire/" sql-file))]
+        target-ns (-> (str "yesquire/" sql-file) (str/replace  #"/" ".") symbol)]
     `(do
        (ns-unalias *ns* '~as)
        (create-ns '~target-ns)

--- a/test/yesql/core_test.clj
+++ b/test/yesql/core_test.clj
@@ -109,6 +109,10 @@
 
 (expect var? #'combined/edge)
 
+(expect first (combined/edge {} {:connection yesql.core-test/derby-db}))
+
 (require-sql ["yesql/sample_files/combined_file.sql" :refer [the-time]])
 
 (expect var? #'the-time)
+
+(expect first (the-time {} {:connection yesql.core-test/derby-db}))


### PR DESCRIPTION
It appears that the require-sql macro doesn't currently work, as it places the functions it defines into an invalid namespace. 

Using the macro like:

```clj
(require-sql ["queries.sql" :as foo])
(foo/my-query ...)
```

Results in:
```
java.lang.IllegalStateException: Attempting to call unbound fn: #'yesquire/queries.sql/my-query
```

since the internal namespace created to hold the functions has an invalid char `/` within it (`yesquire/queries.sql`). 

The tests in `yesql.core-test` also exhibit this problem, but since the functions aren't invoked the problem isn't obvious.

This change fixes the internal namespace in which the query functions are placed by using `.` rather than `/` chars in the ns name. I've also added an actual invocation of the declared query fns into the test to verify that the functions can be called.