### PR TITLE
Allow '-' and '/' in named parameters to enable namespaced keywords

### DIFF
--- a/src/yesql/statement.bnf
+++ b/src/yesql/statement.bnf
@@ -11,6 +11,6 @@ parameter = placeholder-parameter | named-parameter
 
 placeholder-parameter = "?"
 
-named-parameter = <":"> #"[^\s,\"':&;()|=+\-*%/\\<>^\[\]]+"
+named-parameter = <":"> #"[^\s,\"':&;()|=+*%\\<>^\[\]]+"
 
 whitespace = (' ' | '\t')+


### PR DESCRIPTION
This is helpful e.g. when passing clojure.spec conformed map with namespaced
keywords directly as an argument to the generated functions.

For example:

`INSERT INTO table (field) VALUES (:foobar.spec/foo-bar);`