### PR TITLE
Fix create-root-var

### DIFF
--- a/src/yesql/util.clj
+++ b/src/yesql/util.clj
@@ -30,7 +30,7 @@
    (create-root-var *ns* name value))
 
   ([ns name value]
-   (intern *ns*
+   (intern ns
            (with-meta (symbol name)
              (meta value))
            value)))


### PR DESCRIPTION
3-arity create-root-var was calling intern with *ns* instead of ns param