### PR TITLE
Update Python "YeSQL" link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Yesql has inspired ports to other languages:
 |JavaScript|[jsyesql](https://github.com/fanatid/jsyesql)|
 |JavaScript|[Preql](https://github.com/NGPVAN/preql)|
 |JavaScript|[sqlt](https://github.com/eugeneware/sqlt)|
-|Python|[Anosql](https://github.com/honza/anosql)|
+|Python|[aiosql](https://github.com/nackjicholson/aiosql)|
 |Go|[DotSql](https://github.com/gchaincl/dotsql)|
 |Go|[goyesql](https://github.com/nleof/goyesql)|
 |C#|[JaSql](https://bitbucket.org/rick/jasql)|


### PR DESCRIPTION
AnoSQL has been deprecated since 2020.
The AioSQL fork is under active development and maintenance.